### PR TITLE
Fix Typo On Composer Require and composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It currently **only supports HTTP protocol** for :
 To get the latest version of Laravel-FCM on your project, require it from "composer":
 
 
-	$ composer require brozot/laravel-fcm
+	$ composer require apility/laravel-fcm
 
 
 Or you can add it directly in your composer.json file:
@@ -29,7 +29,7 @@ Or you can add it directly in your composer.json file:
 ```json
 {
     "require": {
-        "brozot/laravel-fcm": "1.3.*"
+        "apility/laravel-fcm": "^1.4.*"
     }
 }
 ```


### PR DESCRIPTION
I change the composer required command to


`composer require apility/laravel-fcm`

and also

```
{
    "require": {
        "brozot/laravel-fcm": "1.3.*"
    }
}
```

to

```
{
    "require": {
        "apility/laravel-fcm": "^1.4.*"
    }
}
```